### PR TITLE
Update to use obcj2_metal instead of deprecated metal-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,9 @@ half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_di
 hf-hub = "0.3.2"
 libloading = "0.8.5"
 memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
-metal = "0.29.0"
+objc2 = "0.6.3"
+objc2-foundation = "0.3.2"
+objc2-metal = "0.3.2"
 num = "0.4.3"
 num-traits = "0.2.19"
 num_cpus = "1.16.0"

--- a/ug-llama/Cargo.toml
+++ b/ug-llama/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 clap = { workspace = true }
 cudarc = { workspace = true, optional = true }
 hf-hub = { workspace = true }
-metal = { workspace = true, optional = true }
+objc2-metal = { workspace = true, optional = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 rayon = { workspace = true }
@@ -29,4 +29,4 @@ ug-metal = { workspace = true, optional = true }
 [features]
 default = []
 cuda = ["cudarc", "ug-cuda"]
-metal = ["dep:metal", "ug-metal"]
+metal = ["dep:objc2-metal", "ug-metal"]

--- a/ug-llama/src/metal_ops.rs
+++ b/ug-llama/src/metal_ops.rs
@@ -1,4 +1,5 @@
 use crate::LB;
+use objc2_metal::{MTLResourceUsage, MTLSize};
 use std::sync::OnceLock;
 use ug::{lang::LaunchConfig, Result};
 use ug_metal::runtime::{Func, Slice};
@@ -21,21 +22,21 @@ impl crate::Device for ug_metal::runtime::Device {
         let f = move |vs: Vec<&mut Slice>| -> Result<()> {
             // TODO: check the dtypes.
             let [src, cos, sin, pos, dst]: [&mut Slice; 5] = vs.try_into().unwrap();
-            let cb = device.new_command_buffer();
-            let encoder = cb.new_compute_command_encoder();
+            let cb = device.new_command_buffer()?;
+            let encoder = &mut cb.compute_command_encoder();
             let pl = func.pipeline()?;
             encoder.set_compute_pipeline_state(&pl);
             ug_metal::set_params!(
                 encoder,
                 (&*src, &*cos, &*sin, &*pos, &*dst, (b * h) as u32, (t * d) as u32, d as u32)
             );
-            let grid_size = metal::MTLSize::new(cfg.grid_dim as u64, 1, 1);
-            let threadgroup_size = metal::MTLSize::new(cfg.block_dim as u64, 1, 1);
-            encoder.use_resource(src.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(cos.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(sin.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(pos.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(dst.buffer(), metal::MTLResourceUsage::Write);
+            let grid_size = MTLSize { width: cfg.grid_dim as usize, height: 1, depth: 1 };
+            let threadgroup_size = MTLSize { width: cfg.block_dim as usize, height: 1, depth: 1 };
+            encoder.use_resource(src.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(cos.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(sin.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(pos.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(dst.buffer(), MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, threadgroup_size);
             encoder.end_encoding();
             cb.commit();
@@ -63,21 +64,21 @@ impl crate::Device for ug_metal::runtime::Device {
         let f = move |vs: Vec<&mut Slice>| -> Result<()> {
             // TODO: check the dtypes.
             let [src, cos, sin, pos, dst]: [&mut Slice; 5] = vs.try_into().unwrap();
-            let cb = device.new_command_buffer();
-            let encoder = cb.new_compute_command_encoder();
+            let cb = device.new_command_buffer()?;
+            let encoder = &mut cb.compute_command_encoder();
             let pl = func.pipeline()?;
             encoder.set_compute_pipeline_state(&pl);
             ug_metal::set_params!(
                 encoder,
                 (&*src, &*cos, &*sin, &*pos, &*dst, (b * h) as u32, (t * d) as u32, d as u32)
             );
-            let grid_size = metal::MTLSize::new(cfg.grid_dim as u64, 1, 1);
-            let threadgroup_size = metal::MTLSize::new(cfg.block_dim as u64, 1, 1);
-            encoder.use_resource(src.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(cos.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(sin.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(pos.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(dst.buffer(), metal::MTLResourceUsage::Write);
+            let grid_size = MTLSize { width: cfg.grid_dim as usize, height: 1, depth: 1 };
+            let threadgroup_size = MTLSize { width: cfg.block_dim as usize, height: 1, depth: 1 };
+            encoder.use_resource(src.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(cos.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(sin.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(pos.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(dst.buffer(), MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, threadgroup_size);
             encoder.end_encoding();
             cb.commit();
@@ -121,19 +122,19 @@ impl crate::Device for ug_metal::runtime::Device {
         let device = device.clone();
         let f = move |vs: Vec<&mut Slice>| -> Result<()> {
             let [lhs, rhs, dst]: [&mut Slice; 3] = vs.try_into().unwrap();
-            let cb = device.new_command_buffer();
-            let encoder = cb.new_compute_command_encoder();
+            let cb = device.new_command_buffer()?;
+            let encoder = &mut cb.compute_command_encoder();
             let pl = func.pipeline()?;
             encoder.set_compute_pipeline_state(&pl);
             ug_metal::set_params!(
                 encoder,
                 (&*lhs, &*rhs, &*dst, d1 as u32, d2_l as u32, d2_r as u32, d2_lr as u32)
             );
-            let grid_size = metal::MTLSize::new(cfg.grid_dim as u64, 1, 1);
-            let threadgroup_size = metal::MTLSize::new(cfg.block_dim as u64, 1, 1);
-            encoder.use_resource(lhs.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(rhs.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(dst.buffer(), metal::MTLResourceUsage::Write);
+            let grid_size = MTLSize { width: cfg.grid_dim as usize, height: 1, depth: 1 };
+            let threadgroup_size = MTLSize { width: cfg.block_dim as usize, height: 1, depth: 1 };
+            encoder.use_resource(lhs.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(rhs.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(dst.buffer(), MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, threadgroup_size);
             encoder.end_encoding();
             cb.commit();
@@ -158,15 +159,15 @@ impl crate::Device for ug_metal::runtime::Device {
         let device = device.clone();
         let f = move |vs: Vec<&mut Slice>| -> Result<()> {
             let [src, dst]: [&mut Slice; 2] = vs.try_into().unwrap();
-            let cb = device.new_command_buffer();
-            let encoder = cb.new_compute_command_encoder();
+            let cb = device.new_command_buffer()?;
+            let encoder = &mut cb.compute_command_encoder();
             let pl = func.pipeline()?;
             encoder.set_compute_pipeline_state(&pl);
             ug_metal::set_params!(encoder, (num_elements as u32, dim_m1 as u32, &*src, &*dst));
-            let grid_size = metal::MTLSize::new(cfg.grid_dim as u64, 1, 1);
-            let threadgroup_size = metal::MTLSize::new(cfg.block_dim as u64, 1, 1);
-            encoder.use_resource(src.buffer(), metal::MTLResourceUsage::Read);
-            encoder.use_resource(dst.buffer(), metal::MTLResourceUsage::Write);
+            let grid_size = MTLSize { width: cfg.grid_dim as usize, height: 1, depth: 1 };
+            let threadgroup_size = MTLSize { width: cfg.block_dim as usize, height: 1, depth: 1 };
+            encoder.use_resource(src.buffer(), MTLResourceUsage::Read);
+            encoder.use_resource(dst.buffer(), MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, threadgroup_size);
             encoder.end_encoding();
             cb.commit();

--- a/ug-metal/Cargo.toml
+++ b/ug-metal/Cargo.toml
@@ -9,8 +9,9 @@ categories.workspace = true
 license.workspace = true
 
 [dependencies]
-metal = { workspace = true }
-objc = { workspace = true }
+objc2 = { workspace = true }
+objc2-foundation = { workspace = true }
+objc2-metal = { workspace = true }
 half = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/ug-metal/examples/metal_bench.rs
+++ b/ug-metal/examples/metal_bench.rs
@@ -1,7 +1,10 @@
 // This benchmark has a setup similar to the triton benchmark:
 // https://triton-lang.org/main/getting-started/tutorials/02-fused-softmax.html
+
+use objc2_metal::{MTLResourceUsage, MTLSize};
 use rand::Rng;
 use ug::Result;
+use ug_metal::create_command_buffer;
 
 #[derive(clap::ValueEnum, Clone, Debug)]
 enum Which {
@@ -78,18 +81,19 @@ fn run_one(args: &Args, n_cols: usize) -> Result<()> {
     let res = device.zeros::<f32>(n_elements)?;
     let arg: Vec<f32> = (0..n_elements).map(|_| rng.gen()).collect();
     let arg = device.slice_from_values(&arg)?;
-    let cq = device.new_command_queue();
+
+    let cq = device.new_command_queue()?;
     let run = || {
-        let cb = cq.new_command_buffer();
+        let cb = create_command_buffer(&cq)?;
         let (arg, res) = (arg.buffer(), res.buffer());
-        let encoder = cb.new_compute_command_encoder();
+        let encoder = &mut cb.compute_command_encoder();
         let pl = func.pipeline()?;
         encoder.set_compute_pipeline_state(&pl);
         ug_metal::set_params!(encoder, (arg, res));
-        encoder.use_resource(arg, metal::MTLResourceUsage::Read);
-        encoder.use_resource(res, metal::MTLResourceUsage::Write);
-        let grid_size = metal::MTLSize::new(n_rows as u64, 1, 1);
-        let threadgroup_size = metal::MTLSize::new(usize::min(block_dim, 1024) as u64, 1, 1);
+        encoder.use_resource(arg, MTLResourceUsage::Read);
+        encoder.use_resource(res, MTLResourceUsage::Write);
+        let grid_size = MTLSize { width: n_rows, height: 1, depth: 1 };
+        let threadgroup_size = MTLSize { width: usize::min(block_dim, 1024), height: 1, depth: 1 };
         encoder.dispatch_thread_groups(grid_size, threadgroup_size);
         // Somehow, using dispatch_threads with non-even group size doesn't work properly here.
         encoder.end_encoding();
@@ -125,7 +129,7 @@ fn main() -> Result<()> {
     if !args.disable_metal_validation {
         std::env::set_var("METAL_DEVICE_WRAPPER_TYPE", "1")
     }
-    objc::rc::autoreleasepool(|| {
+    objc2::rc::autoreleasepool(|_pool| {
         for n_cols in [128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096] {
             run_one(&args, n_cols)?;
         }

--- a/ug-metal/src/lib.rs
+++ b/ug-metal/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod code_gen;
+pub mod metal;
 pub mod runtime;
 pub mod utils;
 
+pub use metal::create_command_buffer;
 pub use runtime::{Device, Slice};

--- a/ug-metal/src/metal.rs
+++ b/ug-metal/src/metal.rs
@@ -1,0 +1,438 @@
+use objc2::{rc::Retained, runtime::ProtocolObject};
+use objc2_foundation::{NSRange, NSString};
+use objc2_metal::{
+    MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue, MTLCompileOptions,
+    MTLComputeCommandEncoder, MTLComputePipelineState, MTLCreateSystemDefaultDevice, MTLDataType,
+    MTLDevice, MTLFunction, MTLFunctionConstantValues, MTLLibrary, MTLResource, MTLResourceOptions,
+    MTLResourceUsage, MTLSize,
+};
+use std::{borrow::Cow, ffi::c_void, ptr};
+
+type Error = ug::Error;
+type Result<T> = ug::Result<T>;
+
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct Buffer {
+    raw: Retained<ProtocolObject<dyn MTLBuffer>>,
+}
+
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
+
+impl Buffer {
+    pub fn new(raw: Retained<ProtocolObject<dyn MTLBuffer>>) -> Buffer {
+        Buffer { raw }
+    }
+
+    pub fn contents(&self) -> *mut u8 {
+        self.data()
+    }
+
+    pub fn data(&self) -> *mut u8 {
+        use objc2_metal::MTLBuffer as _;
+        self.as_ref().contents().as_ptr() as *mut u8
+    }
+
+    pub fn length(&self) -> usize {
+        self.as_ref().length()
+    }
+
+    pub fn did_modify_range(&self, range: NSRange) {
+        self.as_ref().didModifyRange(range);
+    }
+}
+
+impl AsRef<ProtocolObject<dyn MTLBuffer>> for Buffer {
+    fn as_ref(&self) -> &ProtocolObject<dyn MTLBuffer> {
+        &self.raw
+    }
+}
+
+pub type MetalResource = ProtocolObject<dyn MTLResource>;
+impl<'a> From<&'a Buffer> for &'a MetalResource {
+    fn from(val: &'a Buffer) -> Self {
+        ProtocolObject::from_ref(val.as_ref())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ComputePipeline {
+    raw: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
+}
+
+unsafe impl Send for ComputePipeline {}
+unsafe impl Sync for ComputePipeline {}
+
+impl ComputePipeline {
+    pub fn new(raw: Retained<ProtocolObject<dyn MTLComputePipelineState>>) -> ComputePipeline {
+        ComputePipeline { raw }
+    }
+
+    pub fn max_total_threads_per_threadgroup(&self) -> usize {
+        self.raw.maxTotalThreadsPerThreadgroup()
+    }
+}
+
+impl AsRef<ProtocolObject<dyn MTLComputePipelineState>> for ComputePipeline {
+    fn as_ref(&self) -> &ProtocolObject<dyn MTLComputePipelineState> {
+        &self.raw
+    }
+}
+
+pub struct ComputeCommandEncoder {
+    raw: Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>,
+    encoding_ended: bool,
+}
+
+impl AsRef<ComputeCommandEncoder> for ComputeCommandEncoder {
+    fn as_ref(&self) -> &ComputeCommandEncoder {
+        self
+    }
+}
+
+impl ComputeCommandEncoder {
+    pub fn new(
+        raw: Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>,
+    ) -> ComputeCommandEncoder {
+        ComputeCommandEncoder { raw, encoding_ended: false }
+    }
+
+    pub fn set_threadgroup_memory_length(&self, index: usize, length: usize) {
+        unsafe { self.raw.setThreadgroupMemoryLength_atIndex(length, index) }
+    }
+
+    pub fn dispatch_threads(&self, threads_per_grid: MTLSize, threads_per_threadgroup: MTLSize) {
+        self.raw.dispatchThreads_threadsPerThreadgroup(threads_per_grid, threads_per_threadgroup)
+    }
+
+    pub fn dispatch_thread_groups(
+        &self,
+        threadgroups_per_grid: MTLSize,
+        threads_per_threadgroup: MTLSize,
+    ) {
+        self.raw.dispatchThreadgroups_threadsPerThreadgroup(
+            threadgroups_per_grid,
+            threads_per_threadgroup,
+        )
+    }
+
+    pub fn set_buffer(&self, index: usize, buffer: Option<&Buffer>, offset: usize) {
+        unsafe { self.raw.setBuffer_offset_atIndex(buffer.map(|b| b.as_ref()), offset, index) }
+    }
+
+    pub fn set_bytes_directly(&self, index: usize, length: usize, bytes: *const c_void) {
+        let pointer = ptr::NonNull::new(bytes as *mut c_void).unwrap();
+        unsafe { self.raw.setBytes_length_atIndex(pointer, length, index) }
+    }
+
+    pub fn set_bytes<T>(&self, index: usize, data: &T) {
+        let size = core::mem::size_of::<T>();
+        let ptr = ptr::NonNull::new(data as *const T as *mut c_void).unwrap();
+        unsafe { self.raw.setBytes_length_atIndex(ptr, size, index) }
+    }
+
+    pub fn set_compute_pipeline_state(&self, pipeline: &ComputePipeline) {
+        self.raw.setComputePipelineState(pipeline.as_ref());
+    }
+
+    pub fn use_resource<'a>(
+        &self,
+        resource: impl Into<&'a MetalResource>,
+        resource_usage: MTLResourceUsage,
+    ) {
+        self.raw.useResource_usage(resource.into(), resource_usage)
+    }
+
+    pub fn end_encoding(&mut self) {
+        use objc2_metal::MTLCommandEncoder as _;
+        if !self.encoding_ended {
+            self.raw.endEncoding();
+            self.encoding_ended = true;
+        }
+    }
+
+    pub fn encode_pipeline(&mut self, pipeline: &ComputePipeline) {
+        use MTLComputeCommandEncoder as _;
+        self.raw.setComputePipelineState(pipeline.as_ref());
+    }
+}
+
+impl Drop for ComputeCommandEncoder {
+    fn drop(&mut self) {
+        self.end_encoding();
+    }
+}
+
+pub fn create_command_buffer(command_queue: &CommandQueue) -> Result<CommandBuffer> {
+    command_queue
+        .commandBuffer()
+        .map(CommandBuffer::new)
+        .ok_or(Error::Msg("Could not create command buffer".to_string()))
+}
+
+#[derive(Clone, Debug)]
+pub struct CommandBuffer {
+    raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+}
+
+unsafe impl Send for CommandBuffer {}
+unsafe impl Sync for CommandBuffer {}
+
+impl CommandBuffer {
+    pub fn new(raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>) -> Self {
+        Self { raw }
+    }
+
+    pub fn compute_command_encoder(&self) -> ComputeCommandEncoder {
+        self.as_ref().computeCommandEncoder().map(ComputeCommandEncoder::new).unwrap()
+    }
+
+    pub fn commit(&self) {
+        self.raw.commit()
+    }
+
+    pub fn enqueue(&self) {
+        self.raw.enqueue()
+    }
+
+    pub fn set_label(&self, label: &str) {
+        self.as_ref().setLabel(Some(&NSString::from_str(label)))
+    }
+
+    pub fn status(&self) -> MTLCommandBufferStatus {
+        self.raw.status()
+    }
+
+    pub fn error(&self) -> Option<Cow<'_, str>> {
+        unsafe {
+            self.raw.error().map(|error| {
+                let description = error.localizedDescription();
+                let c_str = core::ffi::CStr::from_ptr(description.UTF8String());
+                c_str.to_string_lossy()
+            })
+        }
+    }
+
+    pub fn wait_until_completed(&self) {
+        self.raw.waitUntilCompleted()
+    }
+}
+
+impl AsRef<ProtocolObject<dyn MTLCommandBuffer>> for CommandBuffer {
+    fn as_ref(&self) -> &ProtocolObject<dyn MTLCommandBuffer> {
+        &self.raw
+    }
+}
+
+pub type CommandQueue = Retained<ProtocolObject<dyn MTLCommandQueue>>;
+
+#[derive(Clone, Debug)]
+pub struct Device {
+    raw: Retained<ProtocolObject<dyn MTLDevice>>,
+}
+unsafe impl Send for Device {}
+unsafe impl Sync for Device {}
+
+impl AsRef<ProtocolObject<dyn MTLDevice>> for Device {
+    fn as_ref(&self) -> &ProtocolObject<dyn MTLDevice> {
+        &self.raw
+    }
+}
+
+impl Device {
+    pub fn registry_id(&self) -> u64 {
+        self.as_ref().registryID()
+    }
+
+    pub fn all() -> Vec<Self> {
+        MTLCreateSystemDefaultDevice().into_iter().map(|raw| Device { raw }).collect()
+    }
+
+    pub fn system_default() -> Option<Self> {
+        MTLCreateSystemDefaultDevice().map(|raw| Device { raw })
+    }
+
+    pub fn new_buffer(&self, length: usize, options: MTLResourceOptions) -> Result<Buffer> {
+        self.as_ref()
+            .newBufferWithLength_options(length, options)
+            .map(Buffer::new)
+            .ok_or(Error::Msg("Could not allocate metal buffer".to_string()))
+    }
+
+    pub fn new_buffer_with_data(
+        &self,
+        pointer: *const c_void,
+        length: usize,
+        options: MTLResourceOptions,
+    ) -> Result<Buffer> {
+        let pointer = ptr::NonNull::new(pointer as *mut c_void).unwrap();
+        unsafe {
+            self.as_ref()
+                .newBufferWithBytes_length_options(pointer, length, options)
+                .map(Buffer::new)
+                .ok_or(Error::Msg("Could not allocate metal buffer".to_string()))
+        }
+    }
+
+    pub fn new_library_with_source(
+        &self,
+        source: &str,
+        options: Option<&MTLCompileOptions>,
+    ) -> Result<Library> {
+        let raw = self
+            .as_ref()
+            .newLibraryWithSource_options_error(&NSString::from_str(source), options)
+            .unwrap();
+
+        Ok(Library::new(raw))
+    }
+
+    pub fn new_compute_pipeline_state_with_function(
+        &self,
+        function: &Function,
+    ) -> Result<ComputePipeline> {
+        self.as_ref()
+            .newComputePipelineStateWithFunction_error(function.as_ref())
+            .map(|raw| ComputePipeline::new(raw))
+            .map_err(|err| Error::Msg(format!("Could not create compute pipeline state: {}", err)))
+    }
+
+    pub fn new_command_queue(&self) -> Result<CommandQueue> {
+        self.as_ref()
+            .newCommandQueue()
+            .ok_or(Error::Msg("Could not create command queue".to_string()))
+    }
+}
+
+#[derive(Clone)]
+pub struct Function {
+    raw: Retained<ProtocolObject<dyn MTLFunction>>,
+}
+
+impl AsRef<ProtocolObject<dyn MTLFunction>> for Function {
+    fn as_ref(&self) -> &ProtocolObject<dyn MTLFunction> {
+        &self.raw
+    }
+}
+
+pub struct FunctionConstantValues {
+    raw: Retained<MTLFunctionConstantValues>,
+}
+
+impl FunctionConstantValues {
+    pub fn new() -> FunctionConstantValues {
+        FunctionConstantValues { raw: MTLFunctionConstantValues::new() }
+    }
+
+    pub fn set_constant_value_at_index<T>(&self, value: &T, dtype: MTLDataType, index: usize) {
+        let value = ptr::NonNull::new(value as *const T as *mut c_void).unwrap();
+        unsafe { self.raw.setConstantValue_type_atIndex(value, dtype, index) }
+    }
+}
+
+impl Default for FunctionConstantValues {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Library {
+    raw: Retained<ProtocolObject<dyn MTLLibrary>>,
+}
+unsafe impl Send for Library {}
+unsafe impl Sync for Library {}
+
+impl Library {
+    pub fn new(raw: Retained<ProtocolObject<dyn MTLLibrary>>) -> Library {
+        Library { raw }
+    }
+
+    pub fn get_function(
+        &self,
+        name: &str,
+        constant_values: Option<&ConstantValues>,
+    ) -> Result<Function> {
+        let function = match constant_values {
+            Some(constant_values) => self
+                .raw
+                .newFunctionWithName_constantValues_error(
+                    &NSString::from_str(name),
+                    &constant_values.function_constant_values().raw,
+                )
+                .map_err(|e| Error::Msg(format!("Failed to load function '{}': {}", name, e)))?,
+            None => self
+                .raw
+                .newFunctionWithName(&NSString::from_str(name))
+                .ok_or(Error::Msg(format!("Failed to load function '{}'", name)))?,
+        };
+
+        Ok(Function { raw: function })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Value {
+    USize(usize),
+    Bool(bool),
+    F32(f32),
+    U16(u16),
+}
+
+impl std::hash::Hash for Value {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Value::F32(v) => v.to_bits().hash(state),
+            Value::USize(v) => v.hash(state),
+            Value::U16(v) => v.hash(state),
+            Value::Bool(v) => v.hash(state),
+        }
+    }
+}
+
+impl Value {
+    fn data_type(&self) -> MTLDataType {
+        match self {
+            // usize is usually u64 aka ulong, but can be u32 on 32-bit systems.
+            // https://developer.apple.com/documentation/objectivec/nsuinteger
+            Value::USize(_) => MTLDataType::ULong,
+            Value::F32(_) => MTLDataType::Float,
+            Value::U16(_) => MTLDataType::UShort,
+            Value::Bool(_) => MTLDataType::Bool,
+        }
+    }
+}
+
+/// Not true, good enough for our purposes.
+impl Eq for Value {}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct ConstantValues(Vec<(usize, Value)>);
+
+impl ConstantValues {
+    pub fn new(values: Vec<(usize, Value)>) -> Self {
+        Self(values)
+    }
+
+    fn function_constant_values(&self) -> FunctionConstantValues {
+        let f = FunctionConstantValues::new();
+        for (index, value) in &self.0 {
+            let ty = value.data_type();
+            match value {
+                Value::USize(v) => {
+                    f.set_constant_value_at_index(v, ty, *index);
+                }
+                Value::F32(v) => {
+                    f.set_constant_value_at_index(v, ty, *index);
+                }
+                Value::U16(v) => {
+                    f.set_constant_value_at_index(v, ty, *index);
+                }
+                Value::Bool(v) => {
+                    f.set_constant_value_at_index(v, ty, *index);
+                }
+            }
+        }
+        f
+    }
+}

--- a/ug-metal/src/runtime.rs
+++ b/ug-metal/src/runtime.rs
@@ -1,5 +1,10 @@
+use crate::metal::{
+    create_command_buffer, Buffer, CommandBuffer, CommandQueue, ComputeCommandEncoder,
+    ComputePipeline, ConstantValues, Function, Library, Value,
+};
+use crate::set_params;
 use crate::utils::EncoderParam;
-use metal::{FunctionConstantValues, MTLDataType};
+use objc2_metal::{MTLCompileOptions, MTLResourceOptions, MTLResourceUsage, MTLSize};
 use std::sync::OnceLock;
 use ug::{Error, Result};
 
@@ -35,40 +40,37 @@ impl KernelId {
 
 #[derive(Clone)]
 pub struct Func {
-    inner: metal::Function,
+    inner: Function,
     launch_config: ug::lang::LaunchConfig,
     device: Device,
 }
 
 impl Func {
-    pub fn pipeline(&self) -> Result<metal::ComputePipelineState> {
-        let pipeline =
-            self.device.device.new_compute_pipeline_state_with_function(&self.inner).w()?;
+    pub fn pipeline(&self) -> Result<ComputePipeline> {
+        let pipeline = self.device.device.new_compute_pipeline_state_with_function(&self.inner)?;
         Ok(pipeline)
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct Device {
-    device: metal::Device,
-    cq: metal::CommandQueue,
+    device: crate::metal::Device,
+    cq: CommandQueue,
 }
 
 impl Device {
-    pub fn new_command_queue(&self) -> metal::CommandQueue {
+    pub fn new_command_queue(&self) -> Result<CommandQueue> {
         self.device.new_command_queue()
     }
 
-    pub fn new_command_buffer(&self) -> &metal::CommandBufferRef {
-        self.cq.new_command_buffer()
+    pub fn new_command_buffer(&self) -> Result<CommandBuffer> {
+        create_command_buffer(&self.cq)
     }
 
     pub fn new() -> Result<Self> {
-        let device = match metal::Device::system_default() {
-            Some(device) => device,
-            None => ug::bail!("no default device found"),
-        };
-        let cq = device.new_command_queue();
+        let device = crate::metal::Device::system_default()
+            .ok_or(Error::Msg("No default device found".to_string()))?;
+        let cq = device.new_command_queue()?;
         Ok(Self { device, cq })
     }
 
@@ -79,24 +81,24 @@ impl Device {
         launch_config: ug::lang::LaunchConfig,
     ) -> Result<Func> {
         let lib =
-            self.device.new_library_with_source(metal_code, &metal::CompileOptions::new()).w()?;
-        let inner = lib.get_function(func_name, None).w()?;
+            self.device.new_library_with_source(metal_code, Some(&MTLCompileOptions::new()))?;
+        let inner = lib.get_function(func_name, None)?;
         Ok(Func { inner, device: self.clone(), launch_config })
     }
 
     pub fn zeros<T>(&self, len: usize) -> Result<SliceT<T>> {
-        let options = metal::MTLResourceOptions::StorageModeManaged;
-        let bytes_len = (len * std::mem::size_of::<T>()) as u64;
-        let buffer = self.device.new_buffer(bytes_len, options);
+        let options = MTLResourceOptions::StorageModeShared;
+        let bytes_len = len * std::mem::size_of::<T>();
+        let buffer = self.device.new_buffer(bytes_len, options)?;
         Ok(SliceT { buffer, _phantom: std::marker::PhantomData, len })
     }
 
     pub fn slice_from_values<T>(&self, data: &[T]) -> Result<SliceT<T>> {
-        let options = metal::MTLResourceOptions::StorageModeManaged;
+        let options = MTLResourceOptions::StorageModeShared;
         let ptr = data.as_ptr() as *const std::ffi::c_void;
         let len = data.len();
-        let bytes_len = std::mem::size_of_val(data) as u64;
-        let buffer = self.device.new_buffer_with_data(ptr, bytes_len, options);
+        let bytes_len = std::mem::size_of_val(data);
+        let buffer = self.device.new_buffer_with_data(ptr, bytes_len, options)?;
         Ok(SliceT { buffer, _phantom: std::marker::PhantomData, len })
     }
 }
@@ -106,17 +108,18 @@ impl ug::Device for Device {
     type Func = Func;
 
     fn run(&self, f: &Self::Func, args: &mut [&mut Self::Slice]) -> Result<()> {
-        let cb = self.cq.new_command_buffer();
-        let encoder = cb.new_compute_command_encoder();
+        let cb = self.new_command_buffer()?;
+        let encoder = &mut cb.compute_command_encoder();
         let pl = f.pipeline()?;
         encoder.set_compute_pipeline_state(&pl);
         for (index, arg) in args.iter().enumerate() {
-            <&metal::Buffer>::set_param(encoder, index as u64, &arg.buffer);
-            encoder.use_resource(&arg.buffer, metal::MTLResourceUsage::Read);
-            encoder.use_resource(&arg.buffer, metal::MTLResourceUsage::Write);
+            <&Buffer>::set_param(&encoder, index, &arg.buffer);
+            encoder.use_resource(&arg.buffer, MTLResourceUsage::Read);
+            encoder.use_resource(&arg.buffer, MTLResourceUsage::Write);
         }
-        let grid_size = metal::MTLSize::new(f.launch_config.grid_dim as u64, 1, 1);
-        let threadgroup_size = metal::MTLSize::new(f.launch_config.block_dim as u64, 1, 1);
+        let grid_size = MTLSize { width: f.launch_config.grid_dim as usize, height: 1, depth: 1 };
+        let threadgroup_size =
+            MTLSize { width: f.launch_config.block_dim as usize, height: 1, depth: 1 };
         encoder.dispatch_thread_groups(grid_size, threadgroup_size);
         // Somehow, using dispatch_threads with non-even group size doesn't work properly here.
         encoder.end_encoding();
@@ -134,8 +137,8 @@ impl ug::Device for Device {
         lhs_l: &ug::Layout,
         rhs_l: &ug::Layout,
     ) -> Result<()> {
-        let cb = self.cq.new_command_buffer();
-        let encoder = cb.new_compute_command_encoder();
+        let cb = self.new_command_buffer()?;
+        let encoder = &mut cb.compute_command_encoder();
         call_mlx_gemm(
             &dst.device,
             encoder,
@@ -174,9 +177,9 @@ impl ug::Device for Device {
     }
 
     unsafe fn allocate_uninit(&self, dtype: ug::DType, len: usize) -> Result<Self::Slice> {
-        let options = metal::MTLResourceOptions::StorageModeManaged;
-        let bytes_len = (len * dtype.size_in_bytes()) as u64;
-        let buffer = self.device.new_buffer(bytes_len, options);
+        let options = MTLResourceOptions::StorageModeShared;
+        let bytes_len = len * dtype.size_in_bytes();
+        let buffer = self.device.new_buffer(bytes_len, options)?;
         Ok(Slice { buffer, device: self.clone(), len, dtype })
     }
 
@@ -187,7 +190,7 @@ impl ug::Device for Device {
 
 #[derive(Debug, Clone)]
 pub struct SliceT<T> {
-    buffer: metal::Buffer,
+    buffer: Buffer,
     _phantom: std::marker::PhantomData<T>,
     len: usize,
 }
@@ -218,7 +221,7 @@ impl<T: Clone> SliceT<T> {
         slice.to_vec()
     }
 
-    pub fn buffer(&self) -> &metal::Buffer {
+    pub fn buffer(&self) -> &Buffer {
         &self.buffer
     }
 }
@@ -226,7 +229,7 @@ impl<T: Clone> SliceT<T> {
 #[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct Slice {
-    buffer: metal::Buffer,
+    buffer: Buffer,
     device: Device,
     dtype: ug::DType,
     len: usize,
@@ -288,7 +291,7 @@ impl ug::Slice for Slice {
 }
 
 impl Slice {
-    pub fn buffer(&self) -> &metal::Buffer {
+    pub fn buffer(&self) -> &Buffer {
         &self.buffer
     }
 }
@@ -300,103 +303,21 @@ pub enum GemmDType {
     F32,
 }
 
-#[derive(Debug, PartialEq)]
-pub enum Value {
-    USize(usize),
-    Bool(bool),
-    F32(f32),
-    U16(u16),
-}
-
-impl std::hash::Hash for Value {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match self {
-            Value::F32(v) => v.to_bits().hash(state),
-            Value::USize(v) => v.hash(state),
-            Value::U16(v) => v.hash(state),
-            Value::Bool(v) => v.hash(state),
-        }
-    }
-}
-
-impl Value {
-    fn data_type(&self) -> MTLDataType {
-        match self {
-            Value::USize(_) => MTLDataType::UInt,
-            Value::F32(_) => MTLDataType::Float,
-            Value::U16(_) => MTLDataType::UShort,
-            Value::Bool(_) => MTLDataType::Bool,
-        }
-    }
-}
-
-/// Not true, good enough for our purposes.
-impl Eq for Value {}
-
-#[derive(Debug, Eq, PartialEq, Hash)]
-struct ConstantValues(Vec<(usize, Value)>);
-
-impl ConstantValues {
-    pub fn new(values: Vec<(usize, Value)>) -> Self {
-        Self(values)
-    }
-
-    fn function_constant_values(&self) -> FunctionConstantValues {
-        use std::ffi::c_void;
-        let f = FunctionConstantValues::new();
-        for (index, value) in &self.0 {
-            let ty = value.data_type();
-            match value {
-                Value::USize(v) => {
-                    f.set_constant_value_at_index(
-                        v as *const usize as *const c_void,
-                        ty,
-                        *index as u64,
-                    );
-                }
-                Value::F32(v) => {
-                    f.set_constant_value_at_index(
-                        v as *const f32 as *const c_void,
-                        ty,
-                        *index as u64,
-                    );
-                }
-                Value::U16(v) => {
-                    f.set_constant_value_at_index(
-                        v as *const u16 as *const c_void,
-                        ty,
-                        *index as u64,
-                    );
-                }
-                Value::Bool(v) => {
-                    f.set_constant_value_at_index(
-                        v as *const bool as *const c_void,
-                        ty,
-                        *index as u64,
-                    );
-                }
-            }
-        }
-        f
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 fn call_mlx_gemm(
     device: &Device,
-    encoder: &metal::ComputeCommandEncoderRef,
+    encoder: &ComputeCommandEncoder,
     dtype: GemmDType,
     (b, m, n, k): (usize, usize, usize, usize),
     lhs_stride: &[usize],
     lhs_offset: usize,
-    lhs_buffer: &metal::Buffer,
+    lhs_buffer: &Buffer,
     rhs_stride: &[usize],
     rhs_offset: usize,
-    rhs_buffer: &metal::Buffer,
-    output: &metal::Buffer,
+    rhs_buffer: &Buffer,
+    output: &Buffer,
 ) -> Result<()> {
-    use std::ffi::c_void;
-    static LIB: OnceLock<core::result::Result<metal::Library, String>> = OnceLock::new();
+    static LIB: OnceLock<Result<Library>> = OnceLock::new();
 
     #[derive(Debug)]
     #[repr(C)]
@@ -501,45 +422,46 @@ fn call_mlx_gemm(
 
     // TODO: Avoid recompiling the code for each matmul.
     let lib = LIB.get_or_init(|| {
-        device.device.new_library_with_source(MLX_GEMM, &metal::CompileOptions::new())
+        device.device.new_library_with_source(MLX_GEMM, Some(&MTLCompileOptions::new()))
     });
     let lib = match lib {
         Ok(lib) => lib,
         Err(err) => ug::bail!("error compiling the gemm kernels {err}"),
     };
-    let func =
-        lib.get_function(name, constants.as_ref().map(|c| c.function_constant_values())).w()?;
+    let func = lib.get_function(name, constants.as_ref())?;
 
-    let pipeline = device.device.new_compute_pipeline_state_with_function(&func).w()?;
+    let pipeline = device.device.new_compute_pipeline_state_with_function(&func)?;
     encoder.set_compute_pipeline_state(&pipeline);
-    encoder.set_buffer(0, Some(lhs_buffer), lhs_offset as metal::NSUInteger);
-    encoder.set_buffer(1, Some(rhs_buffer), rhs_offset as metal::NSUInteger);
-    encoder.set_buffer(3, Some(output), 0);
-    encoder.set_bytes(
-        4,
-        std::mem::size_of::<GemmParams>() as u64,
-        &gemm_params as *const GemmParams as *const c_void,
-    );
-    encoder.set_bytes(
-        6, // batch_shape
-        std::mem::size_of::<i32>() as u64,
-        &(b as i32) as *const i32 as *const c_void,
-    );
-    encoder.set_bytes(
-        7,
-        (std::mem::size_of::<isize>() * batch_strides.len()) as u64,
-        batch_strides.as_ptr() as *const c_void,
+
+    impl EncoderParam for GemmParams {
+        fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+            encoder.set_bytes(position, &data);
+        }
+    }
+
+    set_params!(
+        encoder,
+        (
+            (lhs_buffer, lhs_offset),
+            (rhs_buffer, rhs_offset),
+            (),
+            output,
+            gemm_params,
+            (),
+            b as i32,
+            &batch_strides[..]
+        )
     );
 
-    let grid_size = metal::MTLSize {
-        width: tn as u64,
-        height: tm as u64,
-        depth: /* batch_size_out */ b as u64,
+    let grid_size = MTLSize {
+        width: tn,
+        height: tm,
+        depth: /* batch_size_out */ b,
     };
-    let group_size = metal::MTLSize { width: 32, height: wn, depth: wm };
-    encoder.use_resource(lhs_buffer, metal::MTLResourceUsage::Read);
-    encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
-    encoder.use_resource(output, metal::MTLResourceUsage::Write);
+    let group_size = MTLSize { width: 32, height: wn, depth: wm };
+    encoder.use_resource(lhs_buffer, MTLResourceUsage::Read);
+    encoder.use_resource(rhs_buffer, MTLResourceUsage::Read);
+    encoder.use_resource(output, MTLResourceUsage::Write);
     encoder.dispatch_thread_groups(grid_size, group_size);
     Ok(())
 }

--- a/ug-metal/src/utils.rs
+++ b/ug-metal/src/utils.rs
@@ -1,7 +1,6 @@
-use metal::{Buffer, ComputeCommandEncoderRef};
-use std::ffi::c_void;
+use crate::metal::{Buffer, ComputeCommandEncoder};
 
-pub fn set_param<P: EncoderParam>(encoder: &ComputeCommandEncoderRef, position: u64, data: P) {
+pub fn set_param<P: EncoderParam>(encoder: &ComputeCommandEncoder, position: usize, data: P) {
     <P as EncoderParam>::set_param(encoder, position, data)
 }
 
@@ -9,17 +8,13 @@ pub fn set_param<P: EncoderParam>(encoder: &ComputeCommandEncoderRef, position: 
 /// on a single line.
 /// Prevents getting wrong some arguments number and mixing length and size in bytes.
 pub trait EncoderParam {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self);
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self);
 }
 macro_rules! primitive {
     ($type:ty) => {
         impl EncoderParam for $type {
-            fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
-                encoder.set_bytes(
-                    position,
-                    core::mem::size_of::<$type>() as u64,
-                    &data as *const $type as *const c_void,
-                );
+            fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+                encoder.set_bytes(position, &data);
             }
         }
     };
@@ -33,49 +28,49 @@ primitive!(u64);
 primitive!(f32);
 
 impl<T> EncoderParam for &[T] {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
-        encoder.set_bytes(
-            position,
-            core::mem::size_of_val(data) as u64,
-            data.as_ptr() as *const c_void,
-        );
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes_directly(position, core::mem::size_of_val(data), data.as_ptr().cast());
     }
 }
 
 impl EncoderParam for &Buffer {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
         encoder.set_buffer(position, Some(data), 0);
     }
 }
 
 impl EncoderParam for (&Buffer, usize) {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
-        encoder.set_buffer(position, Some(data.0), data.1 as u64);
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_buffer(position, Some(data.0), data.1);
     }
 }
 
 impl EncoderParam for &mut Buffer {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
         encoder.set_buffer(position, Some(data), 0);
     }
 }
 
 impl EncoderParam for &crate::runtime::Slice {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
         encoder.set_buffer(position, Some(data.buffer()), 0);
     }
 }
 
 impl EncoderParam for &mut crate::runtime::Slice {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
         encoder.set_buffer(position, Some(data.buffer()), 0);
     }
 }
 
 impl EncoderParam for (&mut Buffer, usize) {
-    fn set_param(encoder: &ComputeCommandEncoderRef, position: u64, data: Self) {
-        encoder.set_buffer(position, Some(data.0), data.1 as u64);
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_buffer(position, Some(data.0), data.1);
     }
+}
+
+impl EncoderParam for () {
+    fn set_param(_: &ComputeCommandEncoder, _: usize, _: Self) {}
 }
 
 #[macro_export]


### PR DESCRIPTION
Metal-rs is [deprecated](https://github.com/gfx-rs/metal-rs/).
This updates ug-metal to use the recommended objc2 bindings instead.
Another bonus from changing to objc2_metal is that metal-rs is currently the largest depencency in candle when building with metal support, because it is brought in from `ug-metal`.

Also updated to use `MTLResourceOptions::StorageModeShared` as it enables iOS support.

The new implementation for metal is basically equal to that in candle. The only difference is that `ComputeCommandEncoder` has a flag that ensures you don't end encoding twice, since `ug-metal` doesn't have the `impl EncoderProvider` and `WrappedEncoder` pattern.

Tests pass.
`ug-llama` fails on metal, but it fails on main as well so I believe the functionality is unchanged.

Feel free to request or make any changes you see fit ☺️ 